### PR TITLE
Throttle GitHub api requests, semver changes, yaml manifest

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -7,6 +7,9 @@ import (
 	"time"
 )
 
+type githubToken struct {
+}
+
 type metrics struct {
 	rancherMajorVersion       prometheus.Gauge
 	rancherMinorVersion       prometheus.Gauge
@@ -119,10 +122,15 @@ func new() metrics {
 
 func Collect(client rancher.Client) {
 	m := new()
+
+	var test int
+
 	ticker := time.NewTicker(3 * time.Second)
 
 	for range ticker.C {
 		log.Info("updating metrics")
+
+		log.Info("var:", test)
 
 		vers, err := client.GetRancherVersion()
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -7,9 +7,6 @@ import (
 	"time"
 )
 
-type githubToken struct {
-}
-
 type metrics struct {
 	rancherMajorVersion       prometheus.Gauge
 	rancherMinorVersion       prometheus.Gauge

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func main() {
 	log.Info("Building Rancher Client")
 
 	// Use this for in-cluster config
-	//config, err := rest.InClusterConfig()david
+	// config, err := rest.InClusterConfig()
 
 	// Use this for out of cluster config
 

--- a/manifests/exporter.yaml
+++ b/manifests/exporter.yaml
@@ -1,8 +1,42 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cattle-system-exporter
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  namespace: cattle-system-exporter
+  name: exporter-role
+rules:
+  - apiGroups: ["management.cattle.io"]
+    resources: ["settings","clusters","nodes"]
+    verbs: ["get", "list"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rancher-exporter
+  namespace: cattle-system-exporter
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rancher-exporter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: exporter-role
+subjects:
+  - kind: ServiceAccount
+    name: rancher-exporter
+    namespace: cattle-system-exporter
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rancher-exporter
-  namespace: default
+  namespace: cattle-system-exporter
 spec:
   selector:
     matchLabels:
@@ -12,10 +46,11 @@ spec:
       labels:
         app: rancher-exporter
     spec:
+      serviceAccountName: rancher-exporter
       containers:
         - imagePullPolicy: Always
           name: rancher-exporter
-          image: virtualthoughts/prometheus-rancher-exporter:0.1
+          image: virtualthoughts/prometheus-rancher-exporter:0.4
           ports:
             - name: metrics
               protocol: TCP
@@ -26,7 +61,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: rancher-exporter
-  namespace: default
+  namespace: cattle-system-exporter
   labels:
     app: rancher-exporter
 spec:
@@ -43,7 +78,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: rancher-exporter
-  namespace: default
+  namespace: cattle-system-exporter
 spec:
   selector:
     matchLabels:

--- a/query/rancher/rancher.go
+++ b/query/rancher/rancher.go
@@ -3,7 +3,6 @@ package rancher
 import (
 	"context"
 	"github.com/ebauman/prometheus-rancher-exporter/semver"
-	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"io"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -87,10 +86,6 @@ func (r Client) GetLatestRancherVersion() (map[string]int64, error) {
 	}
 
 	val := gjson.Get(string(bodyBytes), "tag_name")
-
-	if val.String() == "" {
-		log.Info("Empty")
-	}
 
 	result, err := semver.Parse(TrimVersionChar(val.String()))
 

--- a/query/rancher/rancher.go
+++ b/query/rancher/rancher.go
@@ -73,14 +73,14 @@ func (r Client) GetK8sDistributions() (map[string]int, error) {
 
 func (r Client) GetLatestRancherVersion() (map[string]int64, error) {
 	resp, err := http.Get("https://api.github.com/repos/rancher/rancher/releases/latest")
-	//	defer resp.Body.Close()
+
+	defer resp.Body.Close()
+
 	if err != nil {
 		return nil, err
 	}
 
 	bodyBytes, err := io.ReadAll(resp.Body)
-
-	resp.Body.Close()
 
 	if err != nil {
 		return nil, err

--- a/query/rancher/rancher.go
+++ b/query/rancher/rancher.go
@@ -3,6 +3,7 @@ package rancher
 import (
 	"context"
 	"github.com/ebauman/prometheus-rancher-exporter/semver"
+	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"io"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,18 +73,24 @@ func (r Client) GetK8sDistributions() (map[string]int, error) {
 
 func (r Client) GetLatestRancherVersion() (map[string]int64, error) {
 	resp, err := http.Get("https://api.github.com/repos/rancher/rancher/releases/latest")
-	defer resp.Body.Close()
+	//	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 
+	resp.Body.Close()
+
 	if err != nil {
 		return nil, err
 	}
 
 	val := gjson.Get(string(bodyBytes), "tag_name")
+
+	if val.String() == "" {
+		log.Info("Empty")
+	}
 
 	result, err := semver.Parse(TrimVersionChar(val.String()))
 

--- a/semver/parse.go
+++ b/semver/parse.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 )
 
-const semverregex = "^(?P<major>0|[1-9]\\d*)\\.(?P<minor>0|[1-9]\\d*)\\.(?P<patch>0|[1-9]\\d*)(?:-(?P<prerelease>(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+const semverregex = "^(?P<major>0|[1-9]\\d*)\\.(?P<minor>0|[1-9]\\d*)\\.(?P<patch>0|[1-9]\\d*)"
 
 func Parse(semver string) (map[string]int64, error) {
 	regex := regexp.MustCompile(semverregex)

--- a/types/types.go
+++ b/types/types.go
@@ -1,0 +1,6 @@
+package types
+
+type GithubClient struct {
+	lastModified string
+	etag         string
+}

--- a/types/types.go
+++ b/types/types.go
@@ -1,6 +1,0 @@
-package types
-
-type GithubClient struct {
-	lastModified string
-	etag         string
-}


### PR DESCRIPTION
* Put querying the Github API server into its own goroutine due to throttling 
* Changed semver regex to only acquire major.minor.patch
* Added example YAML manifest to deploy the exporter